### PR TITLE
[QOLSVC-9904] update single sign-on text to reflect QDI expectations

### DIFF
--- a/ckanext/oidc_pkce/templates/user/login.html
+++ b/ckanext/oidc_pkce/templates/user/login.html
@@ -4,11 +4,15 @@ Adds a link from the login form to the single sign-on provider.
 #}
 
 {% block form %}
-    <p><a href="{{ h.url_for('user.login') }}/oidc-pkce" class="btn btn-primary"><i class="fa fa-sign-in"></i> Sign in with your Digital ID</a></p>
+    {% block sso_form %}
+    <p><a href="{{ h.url_for('user.login') }}/oidc-pkce" class="btn btn-primary"><i class="fa fa-sign-in"></i> Log in via single sign-on</a></p>
+    {% endblock %}
     {{ super() }}
 {% endblock %}
 
 {% block help_register_button %}
     {{ super() }}
-    Learn more about using a <a href="https://www.qld.gov.au/qdifaq">Digital ID</a>
+    {% block sso_help_register %}
+    <a href="{{ h.url_for('user.login') }}/oidc-pkce" class="btn btn-secondary">Register via single sign-on</a>
+    {% endblock %}
 {% endblock %}

--- a/ckanext/oidc_pkce/templates/user/login.html
+++ b/ckanext/oidc_pkce/templates/user/login.html
@@ -4,11 +4,11 @@ Adds a link from the login form to the single sign-on provider.
 #}
 
 {% block form %}
-    <p><a href="{{ h.url_for('user.login') }}/oidc-pkce" class="btn btn-primary"><i class="fa fa-sign-in"></i> Log in via single sign-on</a></p>
+    <p><a href="{{ h.url_for('user.login') }}/oidc-pkce" class="btn btn-primary"><i class="fa fa-sign-in"></i> Sign in with your Digital ID</a></p>
     {{ super() }}
 {% endblock %}
 
 {% block help_register_button %}
     {{ super() }}
-    <a href="{{ h.url_for('user.login') }}/oidc-pkce" class="btn btn-secondary">Register via single sign-on</a>
+    Learn more about using a <a href="https://www.qld.gov.au/qdifaq">Digital ID</a>
 {% endblock %}


### PR DESCRIPTION
Provide ability replace login/register text as well as provide 'info' section in theme overrides.

This is to support:
Using the phrase "Sign in with your Digital ID" where appropriate. If your site includes login buttons or text boxes, please consider whether this terminology is relevant for your service.

Optional: Provide a hyperlink and generic “Learn more about using a [Digital ID](https://www.qld.gov.au/qdifaq)” with hyperlink to our FAQs.