### PR TITLE
[QOLDEV-2095] clean up and add CKAN 2.12 tests to workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,7 @@
 
 exclude =
     ckan
+    .git
 
 # Extended output format.
 format = pylint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.x'
       - name: Install requirements
@@ -56,12 +56,8 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         timeout-minutes: 1
-        continue-on-error: ${{ matrix.experimental }}
-
-      - if: ${{ matrix.ckan-version == 2.9 }}
-        run: pip install "setuptools>=44.1.0,<71"
         continue-on-error: ${{ matrix.experimental }}
 
       - name: Install requirements
@@ -85,7 +81,7 @@ jobs:
         continue-on-error: ${{ matrix.experimental }}
 
       - name: Test Summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@v2.6
         continue-on-error: ${{ matrix.experimental }}
         with:
           paths: "/tmp/artifacts/junit/*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,14 @@ on:
       - master
 
 jobs:
+  # Quick check so we don't waste minutes if there's a Flake8 error
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.x'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
@@ -24,13 +25,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: ["2.11", "2.10", 2.9]
+        ckan-version: ['2.12', '2.11', '2.10']
         experimental: [false]
         include:
           - ckan-version: 'master'
-            experimental: true  #master is unstable, good to know if we are compatible or not
+            experimental: true  # master is unstable, good to know if we are compatible or not
 
-    name: Test on CKAN ${{ matrix.ckan-version }}
+    name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} Test on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     container:
       image: ckan/ckan-dev:${{ matrix.ckan-version }}
@@ -46,7 +47,7 @@ jobs:
           POSTGRES_DB: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
-          image: redis:3
+        image: redis
     env:
       CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
       CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test
@@ -55,31 +56,33 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        timeout-minutes: 1
         continue-on-error: ${{ matrix.experimental }}
 
       - if: ${{ matrix.ckan-version == 2.9 }}
-        continue-on-error: ${{ matrix.experimental }}
         run: pip install "setuptools>=44.1.0,<71"
-      - name: Install requirements
         continue-on-error: ${{ matrix.experimental }}
+
+      - name: Install requirements
         # Install any extra requirements your extension has here (dev requirements, other extensions etc)
         run: |
-          pip install -r requirements.txt
-          pip install -r dev-requirements.txt
+          pip install -r requirements.txt -r dev-requirements.txt
           pip install -e .
+        timeout-minutes: 10
+        continue-on-error: ${{ matrix.experimental }}
 
       - name: Setup extension
-        continue-on-error: ${{ matrix.experimental }}
         # Extra initialization steps
         run: |
           # Replace default path to CKAN core config file with the one on the container
           sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
           ckan -c test.ini db init
+        continue-on-error: ${{ matrix.experimental }}
 
       - name: Run tests
-        continue-on-error: ${{ matrix.experimental }}
         run: pytest --ckan-ini=test.ini --cov=ckanext.oidc_pkce --disable-warnings ckanext/oidc_pkce --junit-xml=/tmp/artifacts/junit/results.xml
+        continue-on-error: ${{ matrix.experimental }}
 
       - name: Test Summary
         uses: test-summary/action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-python@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.x'
       - name: Install requirements
@@ -56,7 +56,7 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         timeout-minutes: 1
         continue-on-error: ${{ matrix.experimental }}
 
@@ -81,7 +81,7 @@ jobs:
         continue-on-error: ${{ matrix.experimental }}
 
       - name: Test Summary
-        uses: test-summary/action@v2.6
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         continue-on-error: ${{ matrix.experimental }}
         with:
           paths: "/tmp/artifacts/junit/*.xml"

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Compatibility with core CKAN versions:
 
 | CKAN version | Compatible? |
 |--------------|-------------|
-| 2.9          | yes         |
+| 2.9          | not tested  |
 | 2.10         | yes         |
+| 2.11         | yes         |
+| 2.12         | yes         |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ allowed on the portal.
 
 Compatibility with core CKAN versions:
 
-| CKAN version | Compatible? |
-|--------------|-------------|
-| 2.9          | not tested  |
-| 2.10         | yes         |
-| 2.11         | yes         |
-| 2.12         | yes         |
+| CKAN version | Compatible?          |
+|--------------|----------------------|
+| 2.9          | last tested on 0.4.1 |
+| 2.10         | yes                  |
+| 2.11         | yes                  |
+| 2.12         | yes                  |
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 ]
 maintainers = [
     {name = "DataShades", email = "datashades@linkdigital.com.au"},
+    {name = "Queensland Online Development and Delivery", email = "qol.develoment@smartservice.qld.gov.au"},
 ]
 
 [project.readme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 maintainers = [
     {name = "DataShades", email = "datashades@linkdigital.com.au"},
-    {name = "Queensland Online Development and Delivery", email = "qol.develoment@smartservice.qld.gov.au"},
+    {name = "Queensland Online Development and Delivery", email = "qol.development@smartservice.qld.gov.au"},
 ]
 
 [project.readme]


### PR DESCRIPTION
- Also add D&D to the maintainer list
- Drop CKAN 2.9 as it is obsolete and no longer compatible with the latest GitHub Actions